### PR TITLE
Modified to show toast in current root vc

### DIFF
--- a/Sources/NotificationToast/ToastView.swift
+++ b/Sources/NotificationToast/ToastView.swift
@@ -44,7 +44,12 @@ public class ToastView: UIView {
 
         backgroundColor = viewBackgroundColor
 
-        getTopViewController()?.view.addSubview(self)
+        if let rootViewController = UIApplication.shared.windows.first!.rootViewController {
+            
+            rootViewController.view.addSubview(self)
+            
+        }
+        
         hStack.spacing = iconSpacing
         hStack.axis = .horizontal
         hStack.alignment = .center


### PR DESCRIPTION
Modified to show toast in current root view controller instead of top window. This stops the toast from showing on top of another modal controller if one happens to show up,  and stops it being dragged down with it if it's closed.

The original function 'getTopViewController' is still in place. Might it be useful to create a 'useTopVc' Boolean ?