### PR TITLE
Added "useTopWindow boolean"

### DIFF
--- a/Sources/NotificationToast/ToastView.swift
+++ b/Sources/NotificationToast/ToastView.swift
@@ -44,7 +44,12 @@ public class ToastView: UIView {
 
         backgroundColor = viewBackgroundColor
 
-        getTopViewController()?.view.addSubview(self)
+        if let rootViewController = UIApplication.shared.windows.first!.rootViewController {
+            
+            rootViewController.view.addSubview(self)
+            
+        }
+        
         hStack.spacing = iconSpacing
         hStack.axis = .horizontal
         hStack.alignment = .center

--- a/Sources/NotificationToast/ToastView.swift
+++ b/Sources/NotificationToast/ToastView.swift
@@ -35,6 +35,8 @@ public class ToastView: UIView {
     public var displayTime: TimeInterval = 1
     /// Hide the view automatically on tap ?
     public var hideOnTap = true
+    /// Show on top window, if not use current root VC
+    public var useTopWindow = true
 
     public init(title: String, titleFont: UIFont = .systemFont(ofSize: 13, weight: .regular),
                 subtitle: String? = nil, subtitleFont: UIFont = .systemFont(ofSize: 11, weight: .light),
@@ -44,11 +46,7 @@ public class ToastView: UIView {
 
         backgroundColor = viewBackgroundColor
 
-        if let rootViewController = UIApplication.shared.windows.first!.rootViewController {
-            
-            rootViewController.view.addSubview(self)
-            
-        }
+        getViewController()?.view.addSubview(self)
         
         hStack.spacing = iconSpacing
         hStack.axis = .horizontal
@@ -134,14 +132,18 @@ public class ToastView: UIView {
         backgroundColor = viewBackgroundColor
     }
 
-    private func getTopViewController() -> UIViewController? {
+    private func getViewController() -> UIViewController? {
+        
         let windows = UIApplication.shared.windows
         let keyWindow = windows.count == 1 ? windows.first : windows.filter { $0.isKeyWindow }.first
+        let rootViewController = windows.first!.rootViewController
         if var topController = keyWindow?.rootViewController {
             while let presentedViewController = topController.presentedViewController {
                 topController = presentedViewController
             }
-            return topController
+            
+            return useTopWindow ? topController : rootViewController
+            
         } else {
             return nil
         }


### PR DESCRIPTION
A change which adds the option of showing the toast notification on the top window or the window of the current root controller.

default  useTopWindow = true

Useful if we don't want the toast attaching to any modal view controllers which may pop up. This doesn't make the toast more native feeling but just adds another 
option.