### PR TITLE
fix xcode 13 error by disallowing application extensions.

### DIFF
--- a/Sources/NotificationToast/ToastView.swift
+++ b/Sources/NotificationToast/ToastView.swift
@@ -8,6 +8,7 @@
 import UIKit
 import QuartzCore
 
+@available(iOSApplicationExtension, unavailable)
 public class ToastView: UIView {
     public enum TextAlignment {
         case left


### PR DESCRIPTION
In Xcode 13, 
`
'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.
`
will cause this to fail to compile.

By marking unavailable for iOS app extensions, the problem is resolved. I doubt there will be any use cases for app extensions support so there shouldn't be an impact.